### PR TITLE
Update search results to sort by relevance

### DIFF
--- a/src/Deity/CatalogSearch/Model/CatalogSearchProductList.php
+++ b/src/Deity/CatalogSearch/Model/CatalogSearchProductList.php
@@ -134,6 +134,7 @@ class CatalogSearchProductList implements SearchInterface
             ->addFinalPrice()
             ->addTaxPercents()
             ->addUrlRewrite()
+            ->setOrder('relevance', 'DESC')
             ->setVisibility($this->productVisibility->getVisibleInSearchIds());
 
         $this->queryCollectionService->apply($collection, $query);


### PR DESCRIPTION
Currently the results seem filtered by entity id and not by relevance if we compare vanilla magento

### Please check if the PR fulfills these requirements ###

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes search results to be correct order

**What is the current behavior? (You can also link to an open issue here)**
Currently results are in entity id order of some form

**What is the new behavior (if this is a feature change)?**
Orders by relevance 

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No

